### PR TITLE
Export Transcript Data To JSON

### DIFF
--- a/app.py
+++ b/app.py
@@ -118,6 +118,7 @@ def save_results_to_json(results: list, filename: str):
     except IOError as e:
         logging.error(f"Failed to write to file {filename}: {type(e).__name__}: {e}")
         raise
+    
 if __name__ == "__main__":
     # Example usage TODO: make a proper entry point later
     KEYWORD = "News"

--- a/test_app.py
+++ b/test_app.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 from unittest.mock import MagicMock, patch, mock_open
 from types import SimpleNamespace
@@ -151,39 +152,47 @@ class TestTranscriptsEdgeCases:
 class TestJsonOutput:
     """Tests for the JSON file writing functionality."""
 
-    def test_save_results_to_json_success(self):
+    def test_save_results_to_json_success(self, caplog):
         fake_data = [{'video_id': '123', 'title': 'Test', 'transcript': 'Content'}]
         filename = "test_output.json"
+        
+        # Ensure we capture INFO logs
+        caplog.set_level(logging.INFO)
 
-        # mock_open simulates opening a file handle
-        # json.dump is mocked so we don't actually try to write JSON logic
         with patch("builtins.open", mock_open()) as mocked_file:
             with patch("json.dump") as mocked_dump:
                 
                 save_results_to_json(fake_data, filename)
 
-                # 1. Verify file was opened with write permissions and utf-8
+                # 1. Verify file operations
                 mocked_file.assert_called_once_with(filename, 'w', encoding='utf-8')
-
-                # 2. Verify json.dump was called with the correct data and formatting options
                 mocked_dump.assert_called_once_with(
                     fake_data, 
-                    mocked_file(), # The file handle
+                    mocked_file(), 
                     indent=4, 
                     ensure_ascii=False
                 )
+                
+                # 2. Verify Success Log using caplog
+                assert f"Successfully saved {len(fake_data)} records to {filename}" in caplog.text
 
-    def test_save_results_io_error(self):
-        """Test that the function handles write errors gracefully (logs error)."""
+    def test_save_results_io_error(self, caplog):
+        """Test that the function logs the error AND re-raises the exception."""
         fake_data = []
+        filename = "bad_file.json"
+        
+        # Ensure we capture ERROR logs
+        caplog.set_level(logging.ERROR)
         
         # Simulate a permission denied error
         with patch("builtins.open", mock_open()) as mocked_file:
             mocked_file.side_effect = IOError("Permission denied")
             
-            with patch("logging.error") as mock_log:
-                save_results_to_json(fake_data, "bad_file.json")
-                
-                # Check that we logged the error
-                mock_log.assert_called_once()
-                assert "Failed to write to file" in mock_log.call_args[0][0]
+            # 1. Verify that the exception is re-raised
+            with pytest.raises(IOError):
+                save_results_to_json(fake_data, filename)
+            
+            # 2. Verify the log message was captured by caplog
+            # The log message in your function: f"Failed to write to file {filename}: {type(e).__name__}: {e}"
+            assert f"Failed to write to file {filename}" in caplog.text
+            assert "Permission denied" in caplog.text


### PR DESCRIPTION
Write an adaptor that exports the python
dictionary results out to a JSON file. This
helps with human readability and decoupling
further processing.
Closes #2 